### PR TITLE
GitHub actions: generate debug apk builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,12 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 11
-      uses: actions/setup-java@v2
+    - name: Build Debug APK
+      run: bash ./gradlew :app:assembleDebug
+    - name: Upload Debug APK (Google Play)
+      uses: actions/upload-artifact@v2
       with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
+        name: App-googleplay-debug
+        path: ./app/build/outputs/apk/googlePlay/debug/app-googlePlay-debug.apk
+    - name: Upload Debug APK (F-Droid)
+      uses: actions/upload-artifact@v2
+      with:
+        name: App-fdroid-debug   
+        path: ./app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk


### PR DESCRIPTION
Generate debug builds on commits so that others can download and test them without having to compile it themselves.