### PR TITLE
Fix newline scheme labels

### DIFF
--- a/features/feature-settings/src/main/res/values/strings.xml
+++ b/features/feature-settings/src/main/res/values/strings.xml
@@ -41,8 +41,8 @@
     <string name="view_mode_compact_list">Compact List</string>
     <string name="view_mode_detailed_list">Detailed List</string>
 
-    <string name="linebreak_cr" translatable="false">CR (Mac/Unix)</string>
-    <string name="linebreak_lf" translatable="false">LF (Android/Linux)</string>
+    <string name="linebreak_cr" translatable="false">CR (Mac &lt;=9)</string>
+    <string name="linebreak_lf" translatable="false">LF (Android/Linux/Unix/*)</string>
     <string name="linebreak_crlf" translatable="false">CRLF (Windows)</string>
 
     <string name="pref_header_application_title">Application</string>


### PR DESCRIPTION
Mac has been basically a Unix since OS X 10.0, and Unix has always used LF.

I'm not too attached to these strings, though,
as long as Unix is listed in the LF label
and the CR label clearly refers to old Mac.

(I was going to call it "Ancient Mac" and use "etc."
instead of "*", but those might need translating.)