### PR TITLE
Разрешить клавише [Tab] на клавиатуре конвертировать табуляцию в пробелы

### DIFF
--- a/features/feature-editor/src/main/kotlin/com/blacksquircle/ui/feature/editor/fragments/EditorFragment.kt
+++ b/features/feature-editor/src/main/kotlin/com/blacksquircle/ui/feature/editor/fragments/EditorFragment.kt
@@ -107,7 +107,9 @@ class EditorFragment : Fragment(R.layout.fragment_editor), BackPressedHandler,
         }
         tabController.attachToRecyclerView(binding.tabLayout)
 
-        binding.extendedKeyboard.setKeyListener { char -> binding.editor.insert(char) }
+        binding.extendedKeyboard.setKeyListener {
+            char -> binding.editor.insert(if (char == "\t") binding.editor.tab() else char)
+        }
         binding.extendedKeyboard.setHasFixedSize(true)
 
         binding.editor.onUndoRedoChangedListener = UndoRedoEditText.OnUndoRedoChangedListener {


### PR DESCRIPTION
Чтобы при нажатии клавиши `[Tab]` на клавиатуре (если настроена замена таба на пробелы) вставлялись пробелы вместо табуляции

Не тестировалось, не смог собрать .apk-файл на своём древнем ноуте